### PR TITLE
ChargingControl: Show notification if device is charging

### DIFF
--- a/lineage/lib/main/java/org/lineageos/platform/internal/health/ChargingControlController.java
+++ b/lineage/lib/main/java/org/lineageos/platform/internal/health/ChargingControlController.java
@@ -387,8 +387,10 @@ public class ChargingControlController extends LineageHealthFeature {
         mCurrentProvider.enable();
 
         if (mode == MODE_LIMIT) {
-            if (mCurrentProvider.update(mBatteryPct, limit)) {
+            if (mCurrentProvider.update(mBatteryPct, limit) && mIsPowerConnected) {
                 mChargingNotification.post(limit, mBatteryPct == limit);
+            } else {
+                mChargingNotification.cancel();
             }
         } else {
             ChargeTime chargeTime = getChargeTime();


### PR DESCRIPTION
Enable charge control mode
Set limit to 80% (default value)
Charge to 80% and unplug and restart the device, then there is a charge control notification but the device is not charging